### PR TITLE
Reduce clutter in tiny_solve

### DIFF
--- a/src/tinympc/admm.cpp
+++ b/src/tinympc/admm.cpp
@@ -88,7 +88,7 @@ extern "C"
      * Check for termination condition by evaluating whether the largest absolute
      * primal and dual residuals for states and inputs are below threhold.
      */
-    bool check_termination(TinySolver *solver)
+    bool termination_condition(TinySolver *solver)
     {
         if (solver->work->iter % solver->settings->check_termination == 0)
         {
@@ -132,7 +132,7 @@ extern "C"
             update_linear_cost(solver);
 
             // Check for whether cost is ~minimized~ by calculating residuals
-            if (check_termination(solver)) {
+            if (termination_condition(solver)) {
                 solver->work->status = 1; // TINY_SOLVED
                 return 0;
             }

--- a/src/tinympc/admm.cpp
+++ b/src/tinympc/admm.cpp
@@ -117,6 +117,8 @@ extern "C"
         for (int i = 0; i < solver->settings->max_iter; i++)
         {
 
+            solver->work->iter = i + 1;
+
             // Solve linear system with Riccati and roll out to get new trajectory
             forward_pass(solver);
 
@@ -138,8 +140,6 @@ extern "C"
             // Save previous slack variables
             solver->work->v = solver->work->vnew;
             solver->work->z = solver->work->znew;
-
-            solver->work->iter = i + 1;
 
             backward_pass_grad(solver);
 

--- a/src/tinympc/admm.cpp
+++ b/src/tinympc/admm.cpp
@@ -10,15 +10,6 @@ extern "C"
     static uint64_t startTimestamp;
 
     /**
-     * Do backward Riccati pass then forward roll out
-     */
-    void update_primal(TinySolver *solver)
-    {
-        backward_pass_grad(solver);
-        forward_pass(solver);
-    }
-
-    /**
      * Update linear terms from Riccati backward pass
      */
     void backward_pass_grad(TinySolver *solver)
@@ -93,21 +84,41 @@ extern "C"
         solver->work->p.col(NHORIZON - 1) -= solver->cache->rho * (solver->work->vnew.col(NHORIZON - 1) - solver->work->g.col(NHORIZON - 1));
     }
 
+    /**
+     * Check for termination condition by evaluating whether the largest absolute
+     * primal and dual residuals for states and inputs are below threhold.
+     */
+    bool check_termination(TinySolver *solver)
+    {
+        if (solver->work->iter % solver->settings->check_termination == 0)
+        {
+            solver->work->primal_residual_state = (solver->work->x - solver->work->vnew).cwiseAbs().maxCoeff();
+            solver->work->dual_residual_state = ((solver->work->v - solver->work->vnew).cwiseAbs().maxCoeff()) * solver->cache->rho;
+            solver->work->primal_residual_input = (solver->work->u - solver->work->znew).cwiseAbs().maxCoeff();
+            solver->work->dual_residual_input = ((solver->work->z - solver->work->znew).cwiseAbs().maxCoeff()) * solver->cache->rho;
+
+            if (solver->work->primal_residual_state < solver->settings->abs_pri_tol &&
+                solver->work->primal_residual_input < solver->settings->abs_pri_tol &&
+                solver->work->dual_residual_state < solver->settings->abs_dua_tol &&
+                solver->work->dual_residual_input < solver->settings->abs_dua_tol)
+            {
+                return true;                 
+            }
+        }
+        return false;
+    }
+
     int tiny_solve(TinySolver *solver)
     {
         // Initialize variables
         solver->work->status = 11; // TINY_UNSOLVED
         solver->work->iter = 1;
 
-        forward_pass(solver);
-        update_slack(solver);
-        update_dual(solver);
-        update_linear_cost(solver);
         for (int i = 0; i < solver->settings->max_iter; i++)
         {
 
             // Solve linear system with Riccati and roll out to get new trajectory
-            update_primal(solver);
+            forward_pass(solver);
 
             // Project slack variables into feasible domain
             update_slack(solver);
@@ -118,28 +129,19 @@ extern "C"
             // Update linear control cost terms using reference trajectory, duals, and slack variables
             update_linear_cost(solver);
 
-            if (solver->work->iter % solver->settings->check_termination == 0)
-            {
-                solver->work->primal_residual_state = (solver->work->x - solver->work->vnew).cwiseAbs().maxCoeff();
-                solver->work->dual_residual_state = ((solver->work->v - solver->work->vnew).cwiseAbs().maxCoeff()) * solver->cache->rho;
-                solver->work->primal_residual_input = (solver->work->u - solver->work->znew).cwiseAbs().maxCoeff();
-                solver->work->dual_residual_input = ((solver->work->z - solver->work->znew).cwiseAbs().maxCoeff()) * solver->cache->rho;
-
-                if (solver->work->primal_residual_state < solver->settings->abs_pri_tol &&
-                    solver->work->primal_residual_input < solver->settings->abs_pri_tol &&
-                    solver->work->dual_residual_state < solver->settings->abs_dua_tol &&
-                    solver->work->dual_residual_input < solver->settings->abs_dua_tol)
-                {
-                    solver->work->status = 1; // TINY_SOLVED
-                    return 0;                 // 0 means solved with no error
-                }
+            // Check for whether cost is ~minimized~ by calculating residuals
+            if (check_termination(solver)) {
+                solver->work->status = 1; // TINY_SOLVED
+                return 0;
             }
 
             // Save previous slack variables
             solver->work->v = solver->work->vnew;
             solver->work->z = solver->work->znew;
 
-            solver->work->iter += 1;
+            solver->work->iter = i + 1;
+
+            backward_pass_grad(solver);
 
             // std::cout << solver->work->primal_residual_state << std::endl;
             // std::cout << solver->work->dual_residual_state << std::endl;

--- a/src/tinympc/admm.hpp
+++ b/src/tinympc/admm.hpp
@@ -15,6 +15,7 @@ extern "C"
     void update_slack(TinySolver *solver);
     void update_dual(TinySolver *solver);
     void update_linear_cost(TinySolver *solver);
+    bool check_termination(TinySolver *solver);
 
 #ifdef __cplusplus
 }

--- a/src/tinympc/admm.hpp
+++ b/src/tinympc/admm.hpp
@@ -15,7 +15,7 @@ extern "C"
     void update_slack(TinySolver *solver);
     void update_dual(TinySolver *solver);
     void update_linear_cost(TinySolver *solver);
-    bool check_termination(TinySolver *solver);
+    bool termination_condition(TinySolver *solver);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hey guys, great project and paper!

I want to contribute with the goal of making a Rust port which will similarly run on highly resource constrained hardware.

As far as I can tell, the `tiny_solve` function can be simplified slightly by just doing the backward pass at the end of the of the iteration loop instead of the beginning. Then the `forward_pass`, `update_slack`, `update_dual` and `update_linear_cost` which came before the loop are redundant and can be removed.

I have also moved the residuals/termination check into its own function.