### PR TITLE
Modernize interactive_quadrotor_ext.ipynb

### DIFF
--- a/src/tinympc/admm.cpp
+++ b/src/tinympc/admm.cpp
@@ -31,6 +31,11 @@ void forward_pass(TinySolver *solver)
     }
 }
 
+#ifdef __cplusplus
+}
+extern "C++" {
+#endif
+
 /**
  * Project a vector s onto the second order cone defined by mu
  * @param s, mu
@@ -71,6 +76,11 @@ tinyVector project_hyperplane(const tinyVector& z, const tinyVector& a, tinytype
     tinytype dist = (a.dot(z) - b) / a.squaredNorm();
     return z - dist * a;
 }
+
+#ifdef __cplusplus
+}
+extern "C" {
+#endif
 
 /**
  * Project slack (auxiliary) variables into their feasible domain, defined by

--- a/src/tinympc/admm.hpp
+++ b/src/tinympc/admm.hpp
@@ -16,6 +16,11 @@ void update_dual(TinySolver *solver);
 void update_linear_cost(TinySolver *solver);
 bool termination_condition(TinySolver *solver);
 
+#ifdef __cplusplus
+}
+extern "C++" {
+#endif
+
 /**
  * Project a vector s onto the second order cone defined by mu
  * @param s, mu
@@ -32,6 +37,7 @@ tinyVector project_soc(tinyVector s, float mu);
  * @return Projection of z onto the hyperplane
  */
 tinyVector project_hyperplane(const tinyVector& z, const tinyVector& a, tinytype b);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Fixed a C++ linkage warning by adding `extern "C++"` blocks in `admm.cpp` and `admm.hpp`. The problem was that the projection functions (`project_soc`, `project_hyperplane`) are C++ functions but were being called from C code.
- Updated the code generation to always include sensitivity matrices and generate the `APf`, `BPf`, and `fdyn` vectors. These were all defined in `types.cpp` but were missing from `codegen.cpp`, so they weren't being generated, which was causing errors in the Python API.